### PR TITLE
Remove dependency on requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This project is not yet stable in any way and makes absolutely no guarantees abo
 
 <!-- [[[cog
 import cog
-from issue_expander import issue_expander
+from issue_expander import expander
 from click.testing import CliRunner
 runner = CliRunner()
-result = runner.invoke(issue_expander.cli, ["--help"])
+result = runner.invoke(expander.cli, ["--help"])
 help = result.output.replace("Usage: cli", "Usage: issue-expander")
 cog.out(
     "```\n{}\n```".format(help)

--- a/changelog.d/20230125_013104_adamwolf_requests.md
+++ b/changelog.d/20230125_013104_adamwolf_requests.md
@@ -1,0 +1,38 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Removed
+
+* Removed dependency on requests, to make it easier to package with PyOxidizer. (#37)
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "Click",
-    "requests",
+    "certifi",
     ]
 dynamic = ["readme"]
 
@@ -35,7 +35,6 @@ dev = [
     "tox",
     "pre-commit",
     "pytest",
-    "responses",
     "coverage[toml]",
     "cogapp",
     "scriv"
@@ -50,7 +49,7 @@ Issues = "https://www.github.com/adamwolf/issue-expander/issues"
 readme = {file = ["README.md"], content-type = "text/markdown"}
 
 [project.scripts]
-issue-expander = "issue_expander.issue_expander:cli"
+issue-expander = "issue_expander.expander:cli"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from issue_expander.issue_expander import getIssue
+from issue_expander.expander import getIssue
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_getIssue.py
+++ b/tests/test_getIssue.py
@@ -1,0 +1,95 @@
+import io
+import json
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+import issue_expander
+from issue_expander.expander import getIssue
+
+
+def test_getIssue_with_404(monkeypatch):
+    """getIssue should return None if the issue is not found"""
+
+    def mock_urlopen(request, context=None):
+        raise HTTPError("http://example.com", 404, "Not Found", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(issue_expander.expander, "urlopen", mock_urlopen)
+    assert getIssue("adamwolf", "issue-expander", "1", None, None) is None
+
+
+def test_getIssue_puts_token_in_headers():
+    """getIssue should put the token in the headers as Authorization"""
+
+    with patch(
+        "issue_expander.expander.urlopen",
+        return_value=io.BytesIO(json.dumps({"html_url": "foo", "title": "bar"}).encode("utf-8")),
+    ) as mock_urlopen:
+        assert getIssue("adamwolf", "issue-expander", "1", None, "frobnitz") == {
+            "html_url": "foo",
+            "title": "bar",
+        }
+        mock_urlopen.assert_called_once
+        request_headers = mock_urlopen.call_args[0][0].headers
+        assert request_headers["Authorization"] == "Bearer: frobnitz"
+
+
+def test_getIssue_with_403_without_token(monkeypatch, capsys):
+    """getIssue should return None but print an error if GitHub rate limits us.
+
+    If we didn't pass a token it, it should tell us to try again with a token."""
+
+    def mock_urlopen(request, context=None):
+        raise HTTPError("http://example.com", 403, "Rate limit exceeded.", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(issue_expander.expander, "urlopen", mock_urlopen)
+    assert getIssue("adamwolf", "issue-expander", "1", None, None) is None
+    captured = capsys.readouterr()
+    assert (
+        captured.err
+        == "Unable to look up issue due to rate limit error. Try providing a token with --token.\n"
+    )
+
+
+def test_getIssue_with_403_with_token(monkeypatch, capsys):
+    """getIssue should return None but print an error if GitHub rate limits us.
+
+    If we passed a token in, it shouldn't tell us to try again with a token."""
+
+    def mock_urlopen(request, context=None):
+        raise HTTPError("http://example.com", 403, "Rate limit exceeded.", {}, io.BytesIO(b"foo   "))
+
+    monkeypatch.setattr(issue_expander.expander, "urlopen", mock_urlopen)
+    assert getIssue("adamwolf", "issue-expander", "1", None, "imatoken") is None
+    captured = capsys.readouterr()
+    assert captured.err == "Unable to look up issue due to rate limit error.\n"
+
+
+def test_getIssue_with_malformed_json(monkeypatch, capsys):
+    """getIssue should return None and print an error if the JSON is malformed"""
+
+    def mock_urlopen(request, context=None):
+        raise json.JSONDecodeError("msg", "doc", 0)
+
+    monkeypatch.setattr(issue_expander.expander, "urlopen", mock_urlopen)
+    assert getIssue("adamwolf", "issue-expander", "1", None, None) is None
+
+    captured = capsys.readouterr()
+
+    assert (
+        captured.err
+        == "Unable to parse response from https://api.github.com/repos/adamwolf/issue-expander/issues/1\n"
+    )
+
+
+def test_getIssue_happy_path():
+    """getIssue should return the issue if it's found"""
+
+    with patch(
+        "issue_expander.expander.urlopen",
+        return_value=io.BytesIO(json.dumps({"html_url": "foo", "title": "bar"}).encode("utf-8")),
+    ) as mock_urlopen:
+        assert getIssue("adamwolf", "issue-expander", "1", None, None) == {
+            "html_url": "foo",
+            "title": "bar",
+        }
+        mock_urlopen.assert_called_once

--- a/tests/test_gh_expansions.py
+++ b/tests/test_gh_expansions.py
@@ -1,12 +1,9 @@
-import re
-
 import pytest
-import responses
 
-from issue_expander.issue_expander import expandRefsToMarkdown
+import issue_expander
+from issue_expander.expander import expandRefsToMarkdown
 
 
-@responses.activate
 @pytest.mark.parametrize(
     "input_text,expectation",
     (
@@ -18,30 +15,47 @@ from issue_expander.issue_expander import expandRefsToMarkdown
         ("\n\nGH-100\n", "\n\n[Example Issue #100](https://github.com/foo/bar/issues/100)\n"),
     ),
 )
-def test_gh_issue_expansion(input_text, expectation):
-    """Issue references should be expanded"""
-    responses.get(
-        "https://api.github.com/repos/foo/bar/issues/100",
-        json={
-            "html_url": "https://github.com/foo/bar/issues/100",
-            "title": "Example Issue",
-        },
-    )
+def test_gh_issue_expansion(input_text, expectation, monkeypatch):
+    """Issue references like GH-32 should be expanded"""
+
+    def mockIssue(group, repository, number, username, token):
+        if (
+            group == "foo"
+            and repository == "bar"
+            and number == "100"
+            and username is None
+            and token is None
+        ):
+            return {"html_url": "https://github.com/foo/bar/issues/100", "title": "Example Issue"}
+        else:
+            raise ValueError("Unexpected request")
+
+    monkeypatch.setattr(issue_expander.expander, "getIssue", mockIssue)
 
     expansion = expandRefsToMarkdown(input_text, default_group="foo", default_repository="bar")
     assert expansion == expectation
 
 
-@responses.activate
 @pytest.mark.parametrize(
     "nonexpansion",
     ["GH 100", "G H-100", "G-H-100", "GH- 100", "GH-#100", "GH_100", "GGHH-100", "100-GH", "UGH-100"],
 )
-def test_gh_nonexpansion(nonexpansion):
+def test_gh_nonexpansion(nonexpansion, monkeypatch):
     """Many things with GH in them should not be expanded."""
-    rsp = responses.get(re.compile("http.*"))
+
+    def mockIssue(group, repository, number, username, token):
+        if (
+            group == "foo"
+            and repository == "privaterepo"
+            and number == "555"
+            and username == "johndoe"
+            and token == "password1"
+        ):
+            return {"html_url": "https://example.com/pulls/555", "title": "Sshhh!"}
+        else:
+            raise ValueError("Unexpected request")
+
+    monkeypatch.setattr(issue_expander.expander, "getIssue", mockIssue)
 
     expansion = expandRefsToMarkdown(nonexpansion, default_group="foo", default_repository="bar")
     assert expansion == nonexpansion
-
-    assert rsp.call_count == 0

--- a/tests/test_group_repo_expansions.py
+++ b/tests/test_group_repo_expansions.py
@@ -1,12 +1,9 @@
-import re
-
 import pytest
-import responses
 
-from issue_expander.issue_expander import expandRefsToMarkdown
+import issue_expander
+from issue_expander.expander import expandRefsToMarkdown
 
 
-@responses.activate
 @pytest.mark.parametrize(
     "input_text,expectation",
     (
@@ -18,21 +15,30 @@ from issue_expander.issue_expander import expandRefsToMarkdown
         ("\n\nfoo/bar#100\n", "\n\n[Example Issue #100](https://github.com/foo/bar/issues/100)\n"),
     ),
 )
-def test_group_repo_issue_expansion(input_text, expectation):
+def test_group_repo_issue_expansion(input_text, expectation, monkeypatch):
     """Issue references should be expanded"""
-    responses.get(
-        "https://api.github.com/repos/foo/bar/issues/100",
-        json={
-            "html_url": "https://github.com/foo/bar/issues/100",
-            "title": "Example Issue",
-        },
-    )
+
+    def mockIssue(group, repository, number, username, token):
+        if (
+            group == "foo"
+            and repository == "bar"
+            and number == "100"
+            and username is None
+            and token is None
+        ):
+            return {
+                "html_url": "https://github.com/foo/bar/issues/100",
+                "title": "Example Issue",
+            }
+        else:
+            raise ValueError("Unexpected request")
+
+    monkeypatch.setattr(issue_expander.expander, "getIssue", mockIssue)
 
     expansion = expandRefsToMarkdown(input_text)
     assert expansion == expectation
 
 
-@responses.activate
 @pytest.mark.parametrize(
     "nonexpansion",
     [
@@ -46,11 +52,22 @@ def test_group_repo_issue_expansion(input_text, expectation):
         "foo/bar/#100",
     ],
 )
-def test_group_repo_nonexpansion(nonexpansion):
-    """Many github urls should not be expanded."""
-    rsp = responses.get(re.compile("http.*"))
+def test_group_repo_nonexpansion(nonexpansion, monkeypatch):
+    """Many GitHub urls should not be expanded."""
+
+    def mockIssue(group, repository, number, username, token):
+        if (
+            group == "foo"
+            and repository == "bar"
+            and number == "100"
+            and username is None
+            and token is None
+        ):
+            return {"html_url": "https://github.com/foo/bar/issues/100", "title": "Example Issue"}
+        else:
+            raise ValueError("Unexpected request")
+
+    monkeypatch.setattr(issue_expander.expander, "getIssue", mockIssue)
 
     expansion = expandRefsToMarkdown(nonexpansion)
     assert expansion == nonexpansion
-
-    assert rsp.call_count == 0

--- a/tests/test_issue_cache.py
+++ b/tests/test_issue_cache.py
@@ -1,72 +1,50 @@
-import responses
+import io
+import json
+from unittest.mock import patch
 
-from issue_expander.issue_expander import expandRefsToMarkdown
+from issue_expander.expander import expandRefsToMarkdown
 
 
-@responses.activate
 def test_issue_lookups_are_cached_in_a_line():
     """A line with multiple references to the same issue should only make one API call."""
 
-    fake_issue = responses.get(
-        "https://api.github.com/repos/adamwolf/geewhiz/issues/999",
-        json={
-            "html_url": "https://example.com/issues/999",
-            "title": "Cows don't meow",
-        },
-    )
+    def mock_urlopen(*args, **kwargs):
+        return io.BytesIO(
+            json.dumps(
+                {"html_url": "https://example.com/pulls/101", "title": "Meow, meow, I'm a cow"}
+            ).encode("utf-8")
+        )
 
-    fake_pull = responses.get(
-        "https://api.github.com/repos/adamwolf/geewhiz/issues/101",
-        json={
-            "html_url": "https://example.com/pulls/101",
-            "title": "Meow, meow, I'm a cow",
-        },
-    )
+    with patch("issue_expander.expander.urlopen", side_effect=mock_urlopen) as mock_urlopen:
 
-    expansion = expandRefsToMarkdown("adamwolf/geewhiz#101 adamwolf/geewhiz#999 adamwolf/geewhiz#101")
-    expected = (
-        "[Meow, meow, I'm a cow #101](https://example.com/pulls/101) "
-        "[Cows don't meow #999](https://example.com/issues/999) "
-        "[Meow, meow, I'm a cow #101](https://example.com/pulls/101)"
-    )
+        expansion = expandRefsToMarkdown("adamwolf/geewhiz#101 adamwolf/geewhiz#101")
+        expected = (
+            "[Meow, meow, I'm a cow #101](https://example.com/pulls/101) "
+            "[Meow, meow, I'm a cow #101](https://example.com/pulls/101)"
+        )
 
-    assert expansion == expected
-
-    assert fake_issue.call_count == 1
-    assert fake_pull.call_count == 1
+        assert expansion == expected
+        assert mock_urlopen.call_count == 1
 
 
-@responses.activate
 def test_issue_lookups_are_cached_across_lines():
     """A line with multiple references to the same issue should only make one API call."""
 
-    fake_issue = responses.get(
-        "https://api.github.com/repos/adamwolf/geewhiz/issues/999",
-        json={
-            "html_url": "https://f.com/issues/999",
-            "title": "Cows don't meow",
-        },
-    )
+    def mock_urlopen(*args, **kwargs):
+        return io.BytesIO(
+            json.dumps(
+                {"html_url": "https://example.com/pulls/101", "title": "Meow, meow, I'm a cow"}
+            ).encode("utf-8")
+        )
 
-    fake_pull = responses.get(
-        "https://api.github.com/repos/adamwolf/geewhiz/issues/101",
-        json={
-            "html_url": "https://f.com/pulls/101",
-            "title": "Meow, meow, I'm a cow",
-        },
-    )
+    with patch("issue_expander.expander.urlopen", side_effect=mock_urlopen) as mock_urlopen:
 
-    expansion = expandRefsToMarkdown(
-        "adamwolf/geewhiz#101 adamwolf/geewhiz#999\nadamwolf/geewhiz#101\nadamwolf/geewhiz#999 adamwolf/geewhiz#101"
-    )
-    lines = [
-        "[Meow, meow, I'm a cow #101](https://f.com/pulls/101) [Cows don't meow #999](https://f.com/issues/999)",
-        "[Meow, meow, I'm a cow #101](https://f.com/pulls/101)",
-        "[Cows don't meow #999](https://f.com/issues/999) [Meow, meow, I'm a cow #101](https://f.com/pulls/101)",
-    ]
-    expected = "\n".join(lines)
+        expansion = expandRefsToMarkdown("adamwolf/geewhiz#101\nadamwolf/geewhiz#101\nadamwolf/geewhiz#101")
+        expected = (
+            "[Meow, meow, I'm a cow #101](https://example.com/pulls/101)\n"
+            "[Meow, meow, I'm a cow #101](https://example.com/pulls/101)\n"
+            "[Meow, meow, I'm a cow #101](https://example.com/pulls/101)"
+        )
 
-    assert expansion == expected
-
-    assert fake_issue.call_count == 1
-    assert fake_pull.call_count == 1
+        assert expansion == expected
+        assert mock_urlopen.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ commands = interrogate -vv --fail-under 100 --whitelist-regex "test_.*" tests
 [flake8]
 max-line-length = 108
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, W503


### PR DESCRIPTION
## Describe your changes
This makes it a little nicer to package.

I removed the requests dependency.  I added a
dependency on certifi, which provides Mozilla's
trusted root certificates.

I reworked the tests that used responses, the
library that mocked responses for request.

I moved issue_expander.issue_expander to
issue_expander.expander.

I added an ignore rule to flake8, about newlines
after binary conditions and am following black's
suggestions.

For #36

## Checklist

Do your best!

- [x] I have looked at the changes I am submitting.
- [x] I have written or edited tests to cover these changes.
- [x] I ran tox (or `pre-commit run --all-files` and `pytest`) and there were no warnings.
- [x] I drafted a changelog entry that I created with `scriv create`.
- [x] If this is related to an issue, I have linked to it in this pull request.
