### PR TITLE
Add Changelog link to pyproject.toml for PyPI

### DIFF
--- a/changelog.d/20230127_082754_adamwolf_changelog_pypi.md
+++ b/changelog.d/20230127_082754_adamwolf_changelog_pypi.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Added changelog link to package metadata, so it shows up on PyPI. (#48)
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 Homepage = "https://www.github.com/adamwolf/issue-expander"
 Issues = "https://www.github.com/adamwolf/issue-expander/issues"
 "Source code" = "https://www.github.com/adamwolf/issue-expander"
+Changelog = "https://www.github.com/adamwolf/issue-expander/blob/main/CHANGELOG.md"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}


### PR DESCRIPTION
## Describe your changes

This adds a link to the changelog in the pyproject.toml, so it shows up on PyPI.

See #48

## Checklist

Do your best!

- [X] I have looked at the changes I am submitting.
- [X] I have written or edited tests to cover these changes.
- [X] I ran tox (or `pre-commit run --all-files` and `pytest`) and there were no warnings.
- [X] I drafted a changelog entry that I created with `scriv create`.
- [X] If this is related to an issue, I have linked to it in this pull request.
