### PR TITLE
Add python versions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/issue-expander?color=green&logo=python&logoColor=white)](https://pypi.org/project/issue-expander/)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/adamwolf/4537e853375d0289662b6c7741571cb0/raw/covbadge.json)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/issue_expander)
 
 ```
 $ echo 'rust-lang/rust#106827' | issue-expander -


### PR DESCRIPTION
## Describe your changes
I added a little badge to the README that shows the supported Python versions as pulled from PyPI.

For #50

## Checklist

Do your best!

- [X] I have looked at the changes I am submitting.
- [X] I have written or edited tests to cover these changes.
- [X] I ran tox (or `pre-commit run --all-files` and `pytest`) and there were no warnings.
- [X] I drafted a changelog entry that I created with `scriv create`.
- [X] If this is related to an issue, I have linked to it in this pull request.
